### PR TITLE
Update IP address for api.github.com

### DIFF
--- a/hosts
+++ b/hosts
@@ -78,7 +78,7 @@
 45.95.233.23 open.spotify.com
 
 # GitHub Copilot:
-140.82.121.5 api.github.com
+140.82.121.6 api.github.com
 185.246.223.127 api.individual.githubcopilot.com
 185.246.223.127 proxy.individual.githubcopilot.com
 


### PR DESCRIPTION
the ip address is in Netherlands, Amsterdam
Fixes https://github.com/ImMALWARE/dns.malw.link/issues/15