### PR TITLE
Обновил dnsdist до 2.0.5 для безопасности.

### DIFF
--- a/dns-server/docker-compose.yml
+++ b/dns-server/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   dns:
-    image: powerdns/dnsdist-20:2.0.2
+    image: powerdns/dnsdist-20:2.0.5
     container_name: dnsdist
     ports:
       - "53:53/udp"


### PR DESCRIPTION
Доброго времени, Обновил версию dnsdist до 2.0.5 в docker-compose.yml.
Предыдущая версия (2.0.2) выдавала в логах предупреждение о критической уязвимости (Security Update Mandatory). После обновления до 2.0.5 сообщения об ошибках исчезли. Протестировал на своём сервере в течение суток — система работает стабильно, проблем нет.